### PR TITLE
FAC-469 Make assessment list item maturity level null

### DIFF
--- a/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/assessment/GetSpaceAssessmentListService.java
+++ b/flickit-assessment-core/src/main/java/org/flickit/assessment/core/application/service/assessment/GetSpaceAssessmentListService.java
@@ -1,6 +1,7 @@
 package org.flickit.assessment.core.application.service.assessment;
 
 import lombok.RequiredArgsConstructor;
+import org.flickit.assessment.common.application.domain.assessment.AssessmentPermissionChecker;
 import org.flickit.assessment.common.application.domain.crud.PaginatedResponse;
 import org.flickit.assessment.common.exception.AccessDeniedException;
 import org.flickit.assessment.core.application.domain.AssessmentListItem;
@@ -10,8 +11,10 @@ import org.flickit.assessment.core.application.port.out.spaceuseraccess.CheckSpa
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
+import static org.flickit.assessment.common.application.domain.assessment.AssessmentPermission.VIEW_REPORT_ASSESSMENT;
 import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_NOT_ALLOWED;
 
 @Service
@@ -21,6 +24,7 @@ public class GetSpaceAssessmentListService implements GetSpaceAssessmentListUseC
 
     private final LoadAssessmentListPort loadAssessmentsBySpace;
     private final CheckSpaceAccessPort checkSpaceAccessPort;
+    private final AssessmentPermissionChecker assessmentPermissionChecker;
 
     @Override
     public PaginatedResponse<AssessmentListItem> getAssessmentList(Param param) {
@@ -30,11 +34,35 @@ public class GetSpaceAssessmentListService implements GetSpaceAssessmentListUseC
         if (!checkSpaceAccessPort.checkIsMember(spaceId, currentUserId))
             throw new AccessDeniedException(COMMON_CURRENT_USER_NOT_ALLOWED);
 
-        return loadAssessmentsBySpace.loadSpaceAssessments(
+        var assessmentListItemPaginatedResponse = loadAssessmentsBySpace.loadSpaceAssessments(
             spaceId,
             param.getCurrentUserId(),
             param.getPage(),
             param.getSize()
         );
+
+        List<AssessmentListItem> items = assessmentListItemPaginatedResponse.getItems().stream()
+            .map(e -> {
+                if (!assessmentPermissionChecker.isAuthorized(e.id(), param.getCurrentUserId(), VIEW_REPORT_ASSESSMENT))
+                    return new AssessmentListItem(e.id(),
+                        e.title(),
+                        e.kit(),
+                        e.space(),
+                        e.color(),
+                        e.lastModificationTime(),
+                        null,
+                        e.isCalculateValid(),
+                        e.isConfidenceValid(),
+                        e.manageable());
+                else
+                    return e;
+            }).toList();
+
+        return new PaginatedResponse<>(items,
+            assessmentListItemPaginatedResponse.getPage(),
+            assessmentListItemPaginatedResponse.getSize(),
+            assessmentListItemPaginatedResponse.getSort(),
+            assessmentListItemPaginatedResponse.getOrder(),
+            assessmentListItemPaginatedResponse.getTotal());
     }
 }

--- a/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/assessment/GetSpaceAssessmentListServiceTest.java
+++ b/flickit-assessment-core/src/test/java/org/flickit/assessment/core/application/service/assessment/GetSpaceAssessmentListServiceTest.java
@@ -1,5 +1,7 @@
 package org.flickit.assessment.core.application.service.assessment;
 
+import org.flickit.assessment.common.application.domain.assessment.AssessmentPermission;
+import org.flickit.assessment.common.application.domain.assessment.AssessmentPermissionChecker;
 import org.flickit.assessment.common.application.domain.crud.PaginatedResponse;
 import org.flickit.assessment.common.exception.AccessDeniedException;
 import org.flickit.assessment.core.application.domain.AssessmentListItem;
@@ -21,9 +23,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static org.flickit.assessment.common.application.domain.assessment.AssessmentPermission.VIEW_REPORT_ASSESSMENT;
 import static org.flickit.assessment.common.error.ErrorMessageKey.COMMON_CURRENT_USER_NOT_ALLOWED;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,6 +39,9 @@ class GetSpaceAssessmentListServiceTest {
 
     @Mock
     private CheckSpaceAccessPort checkSpaceAccessPort;
+
+    @Mock
+    private AssessmentPermissionChecker assessmentPermissionChecker;
 
     @Test
     void testGetSpaceAssessmentList_NoResultsFound_NoItemReturned() {
@@ -79,6 +84,8 @@ class GetSpaceAssessmentListServiceTest {
         when(checkSpaceAccessPort.checkIsMember(spaceId, currentUserId)).thenReturn(true);
         when(loadAssessmentPort.loadSpaceAssessments(spaceId, currentUserId, 0, 20))
             .thenReturn(paginatedRes);
+        when(assessmentPermissionChecker.isAuthorized(any(UUID.class), any(UUID.class), any(AssessmentPermission.class)))
+            .thenReturn(true);
 
         var param = new GetSpaceAssessmentListUseCase.Param(spaceId, currentUserId, 20, 0);
         var assessments = service.getAssessmentList(param);
@@ -106,6 +113,36 @@ class GetSpaceAssessmentListServiceTest {
         assertEquals(AssessmentJpaEntity.Fields.LAST_MODIFICATION_TIME, assessments.getSort());
 
         verify(loadAssessmentPort, times(1)).loadSpaceAssessments(any(), any(), anyInt(), anyInt());
+    }
+
+    @Test
+    void testGetSpaceAssessmentList_WhenUserDoesntHaveViewReportAssessmentPermission_ThenItemsMaturityLevelIsNull() {
+        Long spaceId = 123L;
+        var assessment1 = AssessmentMother.assessmentListItem(spaceId, AssessmentKitMother.kit().getId());
+
+        var paginatedRes = new PaginatedResponse<>(
+            List.of(assessment1),
+            0,
+            20,
+            AssessmentJpaEntity.Fields.LAST_MODIFICATION_TIME,
+            Sort.Direction.DESC.name().toLowerCase(),
+            1
+        );
+
+        UUID currentUserId = UUID.randomUUID();
+
+        when(checkSpaceAccessPort.checkIsMember(spaceId, currentUserId)).thenReturn(true);
+        when(loadAssessmentPort.loadSpaceAssessments(spaceId, currentUserId, 0, 20))
+            .thenReturn(paginatedRes);
+        when(assessmentPermissionChecker.isAuthorized(assessment1.id(), currentUserId, VIEW_REPORT_ASSESSMENT))
+            .thenReturn(false);
+
+        var param = new GetSpaceAssessmentListUseCase.Param(spaceId, currentUserId, 20, 0);
+        var assessments = service.getAssessmentList(param);
+
+        List<AssessmentListItem> items = assessments.getItems();
+        assertEquals(1, items.size());
+        assertNull(items.get(0).maturityLevel());
     }
 
     @Test


### PR DESCRIPTION
If current user role doesn't have 'VIEW_REPORT_ASSESSMENT' permission, assessment list item's maturity level should be null. The corresponding tests also fixed.

### Checklist
Before you label your PR as 'Ready To Review', please check the below list and put an 'X' char into each bracket;

[ ] - Did you update the Postman file?
[ ] - Did you update the corresponding document?
[ ] - Did you review the PR by yourself?
[ ] - Did you merge the main branch into this branch recently?
[ ] - Did you remove the probable extra code?
[ ] - Did you label the PR as 'Ready to Review'?
[ ] - Did you update the Jira task to 'In Review'?
[ ] - Did you add the Confluence's link to the Jira task as a description?
